### PR TITLE
chore: add babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": "defaults, not IE 11"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
### Breaking
- Use babel config with default and no IE11 support
- In general drop IE11 support (dev should polyfill regenerator itself ex. `react-app-polyfill/ie11`)

### Reference
- https://caniuse.com/async-functions
- https://github.com/formium/tsdx/releases/tag/v0.14.0
- https://github.com/developit/microbundle/issues/565