### PR TITLE
chore: add babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "targets": "defaults, not IE 11"
+      }
+    ]
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Focused on logic
 - Zero dependencies
 - No UI restrictions
+- [Tiny size](https://bundlephobia.com/result?p=react-use-wizard@latest)
 - Written in TypeScript
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ const Step1 = () => {
 - [Examples](#examples)
 - [Async](#async)
 - [Animation](#animation)
+- [IE11](#ie11)
 
 ## API
 
@@ -227,3 +228,8 @@ If an async function is attached to `handleStep` the `isLoading` property will i
 Since `react-use-wizard` is focused to manage the logic of a wizard it doesn't mean you can't add some animation by your own. Add any animation library that you like. I highly suggest [framer-motion](https://www.framer.com/motion/) to add your animations.
 
 Checkout this [example](https://github.com/devrnt/react-use-wizard/blob/main/playground/components/animatedStep.tsx) to see how a step can be animated with framer motion. 
+
+## IE11
+Since Internet Explorer 11 doesn't support promises or async functions you'll need to install a polyfill for the `regenerator-runtime`.
+
+In general using [react-app-polyfill](https://www.npmjs.com/package/react-app-polyfill) is recommended, it includes polyfills for various browsers.  


### PR DESCRIPTION
### Breaking
- Use babel config with default and no IE11 `target`
- In general drop IE11 support (dev should polyfill regenerator itself ex. `react-app-polyfill/ie11`)

### Reference
- https://caniuse.com/async-functions
- https://github.com/formium/tsdx/releases/tag/v0.14.0
- https://github.com/developit/microbundle/issues/565