### PR TITLE
Unable to go to first page

### DIFF
--- a/src/wizard.tsx
+++ b/src/wizard.tsx
@@ -23,7 +23,7 @@ const Wizard: React.FC<WizardProps> = React.memo(
     });
 
     const goToPreviousStep = React.useRef((stepIndex?: number) => {
-      if (hasPreviousStep.current) {
+      if (hasPreviousStep.current || stepIndex != null) {
         setActiveStep((activeStep) => stepIndex ?? activeStep - 1);
       }
     });


### PR DESCRIPTION
Changed goToNextStep to accept nextStep(0) when you are on the last step
by changing the if statement if (hasNextStep.current || stepIndex) to
if (hasNextStep.current || stepIndex != null), this way, when we try to
go to the first step while being on the last step, the activeStep will be
changed successfully