### PR TITLE
Add step count

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules\\typescript\\lib"
-}

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ const Step1 = () => {
     isLastStep,
     isFirstStep,
     activeStep,
+    stepCount,
     previousStep,
     nextStep,
     goToStep,

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Used to retrieve all methods and properties related to your wizard. Make sure `W
 | handleStep   | (handler: Handler) => void | Attach a callback that will be called when calling `nextStep`.  `handler` can be either sync or async                                                     |
 | isLoading    | boolean                    | \* Will reflect the handler promise state: will be `true` if the handler promise is pending and `false` when the handler is either fulfilled or rejected |
 | activeStep   | number                     | The current active step of the wizard                                                                                                                    |
+| stepCount    | number                     | The total number of steps of the wizard                                                                                                                  |
 | isFirstStep  | boolean                    | Indicate if the current step is the first step (aka no previous step)                                                                                    |
 | isLastStep   | boolean                    | Indicate if the current step is the last step (aka no next step)                                                                                         |
 |              |

--- a/examples/gatsby/src/pages/index.js
+++ b/examples/gatsby/src/pages/index.js
@@ -19,6 +19,7 @@ const Footer = () => {
     previousStep,
     isLoading,
     activeStep,
+    stepCount,
     isLastStep,
     isFirstStep
   } = useWizard();
@@ -32,6 +33,10 @@ const Footer = () => {
         <br />
         <p>
           Active step: {activeStep + 1} <br />
+        </p>
+        <br />
+        <p>
+          Total steps: {stepCount} <br />
         </p>
       </div>
       <div>

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -17,6 +17,7 @@ const Footer = () => {
     previousStep,
     isLoading,
     activeStep,
+    stepCount,
     isLastStep,
     isFirstStep,
   } = useWizard();
@@ -30,6 +31,10 @@ const Footer = () => {
         <br />
         <p>
           Active step: {activeStep + 1} <br />
+        </p>
+        <br />
+        <p>
+          Total steps: {stepCount} <br />
         </p>
       </div>
       <div>

--- a/playground/components/footer/footer.tsx
+++ b/playground/components/footer/footer.tsx
@@ -22,7 +22,7 @@ export const Info = styled('div')`
     margin: 0.25rem 0;
   }
 
-  @media screen and (min-width: 600px) {
+  @media screen and (min-width: 768px) {
     flex-direction: row;
     gap: 1rem;
 
@@ -38,6 +38,7 @@ const Footer: React.FC = () => {
     previousStep,
     isLoading,
     activeStep,
+    stepCount,
     isLastStep,
     isFirstStep,
   } = useWizard();
@@ -52,6 +53,10 @@ const Footer: React.FC = () => {
           <br />
           <p>
             Active step: {activeStep + 1} <br />
+          </p>
+          <br />
+          <p>
+            Total steps: {stepCount} <br />
           </p>
         </Info>
         <Actions>

--- a/playground/components/footer/footerStepIndex.tsx
+++ b/playground/components/footer/footerStepIndex.tsx
@@ -10,6 +10,7 @@ const FooterGoToStepIndex: React.FC = () => {
     previousStep,
     isLoading,
     activeStep,
+    stepCount,
     isLastStep,
     isFirstStep,
   } = useWizard();
@@ -24,6 +25,10 @@ const FooterGoToStepIndex: React.FC = () => {
           <br />
           <p>
             Active step: {activeStep + 1} <br />
+          </p>
+          <br />
+          <p>
+            Total steps: {stepCount} <br />
           </p>
         </Info>
         <Actions>

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export type WizardValues = {
   isLoading: boolean;
   /** The current active step of the wizard */
   activeStep: number;
+  /** The total number of steps of the wizard */
+  stepCount: number;
   /** Indicate if the current step is the first step (aka no previous step) */
   isFirstStep: boolean;
   /** Indicate if the current step is the last step (aka no next step) */

--- a/src/wizard.tsx
+++ b/src/wizard.tsx
@@ -11,9 +11,9 @@ const Wizard: React.FC<WizardProps> = React.memo(
     const hasNextStep = React.useRef(true);
     const hasPreviousStep = React.useRef(false);
     const nextStepHandler = React.useRef<Handler>(() => {});
+    const stepCount = React.Children.count(children);
 
-    hasNextStep.current =
-      activeStep < React.Children.toArray(children).length - 1;
+    hasNextStep.current = activeStep < stepCount - 1;
     hasPreviousStep.current = activeStep > 0;
 
     const goToNextStep = React.useRef(() => {
@@ -29,10 +29,7 @@ const Wizard: React.FC<WizardProps> = React.memo(
     });
 
     const goToStep = React.useRef((stepIndex: number) => {
-      if (
-        stepIndex >= 0 &&
-        stepIndex < React.Children.toArray(children).length
-      ) {
+      if (stepIndex >= 0 && stepIndex < stepCount) {
         setActiveStep(stepIndex);
       } else {
         if (__DEV__) {
@@ -76,11 +73,12 @@ const Wizard: React.FC<WizardProps> = React.memo(
         handleStep: handleStep.current,
         isLoading,
         activeStep,
+        stepCount,
         isFirstStep: !hasPreviousStep.current,
         isLastStep: !hasNextStep.current,
         goToStep: goToStep.current,
       }),
-      [activeStep, isLoading],
+      [activeStep, stepCount, isLoading],
     );
 
     const activeStepContent = React.useMemo(() => {

--- a/test/useWizard.test.tsx
+++ b/test/useWizard.test.tsx
@@ -31,6 +31,12 @@ describe('useWizard', () => {
     expect(result.current.activeStep).toBe(0);
   });
 
+  test('should set step count to two', () => {
+    const { result } = renderUseWizardHook();
+
+    expect(result.current.stepCount).toBe(2);
+  });
+
   test('should set active step to one', () => {
     const { result } = renderUseWizardHook(1);
 


### PR DESCRIPTION
**Changes**  
Add `stepCount` to `useWizard` hook context values. Holds the total number of steps.

I have added tests and updated documentation/examples accordingly.

**Motivation**  
Useful for displaying progress, like `Step 1 of 4`.

One could keep track of the step count outside the wizard, but it's cumbersome to calculate/pass around. Feels like a natural part of a wizard and fits well into the rest of the context values.

**Remaining**  
I've gone ahead and prepared (and verified) the `playground/` and `examples/` as well. However, the `examples/` need to update to the new version of `react-use-wizard` whenever available. 

Closes #87
