### PR TITLE
Add key to animated section list

### DIFF
--- a/playground/modules/wizard/animated/index.tsx
+++ b/playground/modules/wizard/animated/index.tsx
@@ -16,7 +16,7 @@ const AnimatedSection: React.FC = () => {
             .fill(null)
             .map((_, index) => {
               return (
-                <AnimatedStep previousStep={previousStep}>
+                <AnimatedStep key={index} previousStep={previousStep}>
                   <Step number={index + 1} withCallback={false}></Step>
                 </AnimatedStep>
               );


### PR DESCRIPTION
To remove console warning about unique keys for list items. Using index in lack of a more appropriate key.
