### PR TITLE
make sure stepCount doesn't count false / null or undefined child items

### DIFF
--- a/src/wizard.tsx
+++ b/src/wizard.tsx
@@ -11,7 +11,7 @@ const Wizard: React.FC<WizardProps> = React.memo(
     const hasNextStep = React.useRef(true);
     const hasPreviousStep = React.useRef(false);
     const nextStepHandler = React.useRef<Handler>(() => {});
-    const stepCount = React.Children.count(children);
+    const stepCount = React.Children.toArray(children).length;
 
     hasNextStep.current = activeStep < stepCount - 1;
     hasPreviousStep.current = activeStep > 0;

--- a/test/useWizard.test.tsx
+++ b/test/useWizard.test.tsx
@@ -12,6 +12,7 @@ const renderUseWizardHook = (initialStartIndex = 0) => {
     wrapper: ({ children, startIndex }) => (
       <Wizard startIndex={startIndex}>
         <p>step 1 {children}</p>
+        {false && <p>Optional step</p>}
         <p>step 2 {children}</p>
       </Wizard>
     ),


### PR DESCRIPTION
When using optional steps in your Wizard the new stepCount property didn't match. 
This is because `React.Children.count()` will also count the null or false values in jsx. 

When converting to children toArray only valid JSX is allowed so we get the actual child count.