### PR TITLE
Fix React 18 FunctionalComponent bug

### DIFF
--- a/src/wizard.tsx
+++ b/src/wizard.tsx
@@ -4,7 +4,7 @@ import * as logger from './logger';
 import { Handler, WizardProps } from './types';
 import WizardContext from './wizardContext';
 
-const Wizard: React.FC<WizardProps> = React.memo(
+const Wizard: React.FC<React.PropsWithChildren<WizardProps>> = React.memo(
   ({ header, footer, children, startIndex = 0 }) => {
     const [activeStep, setActiveStep] = React.useState(startIndex);
     const [isLoading, setIsLoading] = React.useState(false);


### PR DESCRIPTION
## What's been changed
 - Wrapped `WizardProps` in `Wizard.tsx` with `React.PropsWithChildren`

## Why is this needed?

One recent change in React 18 has been an update to the `FunctionComponent` or `FC` types as they have now had the optional `children` property removed ([Source](https://twitter.com/reactjs/status/1512453969490108418)).