### PR TITLE
Fix typings with esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "browser": "./dist/react-use-wizard.mjs",
       "import": "./dist/react-use-wizard.mjs",
       "require": "./dist/index.js"


### PR DESCRIPTION
Hi, thanks for the lib! I am currently using it in my third project and got some type errors. This error appears when `"moduleResolution"` is set to `"bundler"`  in tsconfig.json.

```
TS7016: Could not find a declaration file for module 'react-use-wizard'.
'/path/to/my/project/node_modules/react-use-wizard/dist/react-use-wizard.esm.js' implicitly has an 'any' type.

There are types at '/path/to/my/project/node_modules/react-use-wizard/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". 
The 'react-use-wizard' library may need to update its package.json or typings.
```

In my local test, this change fixed it.