### PR TITLE
Update step count when steps are dynamically rendered

### DIFF
--- a/src/wizard.tsx
+++ b/src/wizard.tsx
@@ -15,10 +15,26 @@ const Wizard: React.FC<React.PropsWithChildren<WizardProps>> = React.memo(
       React.Children.toArray(children).length,
     );
 
+    // Disable exhaustive-deps warning for this effect.
+    // The reason is because we only want this effect to run
+    // when the number of children changes, and not also when activeStep changes.
+    /* eslint-disable react-hooks/exhaustive-deps */
     React.useEffect(() => {
       const newCount = React.Children.toArray(children).length;
       setStepCount(newCount);
+
+      if (activeStep >= newCount) {
+        setActiveStep(newCount - 1);
+
+        if (__DEV__) {
+          logger.log(
+            'warn',
+            `Number of steps have been changed to ${newCount} while activeStep exceeds the new count. The last step will be actived.`,
+          );
+        }
+      }
     }, [children]);
+    /* eslint-enable react-hooks/exhaustive-deps */
 
     hasNextStep.current = activeStep < stepCount - 1;
     hasPreviousStep.current = activeStep > 0;

--- a/src/wizard.tsx
+++ b/src/wizard.tsx
@@ -11,7 +11,14 @@ const Wizard: React.FC<React.PropsWithChildren<WizardProps>> = React.memo(
     const hasNextStep = React.useRef(true);
     const hasPreviousStep = React.useRef(false);
     const nextStepHandler = React.useRef<Handler>(() => {});
-    const stepCount = React.Children.toArray(children).length;
+    const [stepCount, setStepCount] = React.useState(
+      React.Children.toArray(children).length,
+    );
+
+    React.useEffect(() => {
+      const newCount = React.Children.toArray(children).length;
+      setStepCount(newCount);
+    }, [children]);
 
     hasNextStep.current = activeStep < stepCount - 1;
     hasPreviousStep.current = activeStep > 0;

--- a/src/wizard.tsx
+++ b/src/wizard.tsx
@@ -17,7 +17,7 @@ const Wizard: React.FC<React.PropsWithChildren<WizardProps>> = React.memo(
 
     // Disable exhaustive-deps warning for this effect.
     // The reason is because we only want this effect to run
-    // when the number of children changes, and not also when activeStep changes.
+    // when the children changes, and not also when activeStep changes.
     /* eslint-disable react-hooks/exhaustive-deps */
     React.useEffect(() => {
       const newCount = React.Children.toArray(children).length;


### PR DESCRIPTION
Fixes #135

At the moment the active step is changed to the last one and a warning is logged if ```activeStep >= newStepCount```.

There's no detection for if a "lower" or the currently rendered step is removed, if that happens the new step at the ```activeStep``` index is rendered/etc. I think that would require a unique identifier for each step instead of an index. Maybe that's something to consider?

I don't think there are any unexpected side effects. All the tests pass at least. Should be backwards compatible since it's functionally identical if the children never change.

(I noticed there's already a branch for this but there's no commits on it.)